### PR TITLE
Use namespaced path for Google Maps context processor

### DIFF
--- a/django_places_autocomplete/myproject/settings.py
+++ b/django_places_autocomplete/myproject/settings.py
@@ -69,7 +69,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
-                "addresses.context_processors.google_maps_api_key",
+                "django_places_autocomplete.addresses.context_processors.google_maps_api_key",
             ],
         },
     },


### PR DESCRIPTION
## Summary
- use fully-qualified `django_places_autocomplete` namespace for Google Maps API key context processor

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688ff80acf0083319adeca03b624749e