### PR TITLE
Organize address views imports

### DIFF
--- a/django_places_autocomplete/addresses/views.py
+++ b/django_places_autocomplete/addresses/views.py
@@ -1,5 +1,7 @@
-from django.shortcuts import render
+from django.core.paginator import Paginator
 from django.http import JsonResponse
+from django.shortcuts import render
+
 from .forms import AddressForm
 from .models import Address
 
@@ -25,8 +27,7 @@ def address_form_view(request):
 
     form = AddressForm()
     return render(request, 'addresses/address_form.html', {'form': form})
-from django.core.paginator import Paginator
-from .models import Address
+
 
 def address_list_view(request):
     qs = Address.objects.order_by('-created_at')


### PR DESCRIPTION
## Summary
- group views imports per PEP8 and remove duplicate Address import

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688ffa58d89c833182560b58e8900b24