### PR TITLE
Add geocode view

### DIFF
--- a/django_places_autocomplete/addresses/urls.py
+++ b/django_places_autocomplete/addresses/urls.py
@@ -1,9 +1,9 @@
-from django.contrib import admin
-from django.urls import path, include
+from django.urls import path
 from . import views
 
 urlpatterns = [
     #path('admin/', admin.site.urls),
     path('', views.address_form_view, name='address_form'),
     path('list/', views.address_list_view, name='address_list'),
+    path('geocode/', views.geocode_view, name='geocode'),
 ]


### PR DESCRIPTION
## Summary
- add geocode_view to handle forward and reverse geocoding
- expose geocode endpoint in addresses URLs

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6890382054f08331ae8f51893d0748b7