### PR TITLE
Add Tailwind CSS build scripts

### DIFF
--- a/django_places_autocomplete/README.md
+++ b/django_places_autocomplete/README.md
@@ -20,3 +20,17 @@ python manage.py runserver
 - Hidden address components
 - AJAX form submission
 - Tailwind CSS styling
+
+### CSS
+
+Build the Tailwind CSS assets:
+
+```bash
+npm run build:css
+```
+
+Watch for changes during development:
+
+```bash
+npm run watch:css
+```

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build:css": "npx tailwindcss -c tailwind.config.js -i assets/css/input.css -o django_places_autocomplete/static/css/app.css --minify",
+    "watch:css": "npx tailwindcss -c tailwind.config.js -i assets/css/input.css -o django_places_autocomplete/static/css/app.css --watch"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- add scripts to build and watch Tailwind CSS
- document CSS build commands in README

## Testing
- `python manage.py test`
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68903e4f5c84833194796b38b2c89164