### PR TITLE
Add caching for geocoding services

### DIFF
--- a/django_places_autocomplete/addresses/services.py
+++ b/django_places_autocomplete/addresses/services.py
@@ -6,6 +6,7 @@ from typing import Dict, List
 
 import requests
 from django.conf import settings
+from django.core.cache import cache
 
 GEOCODE_ENDPOINT = "https://maps.googleapis.com/maps/api/geocode/json"
 
@@ -55,6 +56,9 @@ def _handle_response(data: Dict) -> List[Dict]:
 def geocode_forward(address: str) -> List[Dict]:
     """Forward geocode an address string using the Google Geocoding API.
 
+    Results are cached using the Django cache framework keyed by the
+    provided ``address``.
+
     Parameters
     ----------
     address: str
@@ -66,14 +70,24 @@ def geocode_forward(address: str) -> List[Dict]:
         A list of simplified geocoding results.
     """
 
+    cache_key = f"geocode_forward:{address}"
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return cached
+
     params = {"address": address, "key": settings.GOOGLE_MAPS_API_KEY}
     response = requests.get(GEOCODE_ENDPOINT, params=params, timeout=10)
     data = response.json()
-    return _handle_response(data)
+    results = _handle_response(data)
+    cache.set(cache_key, results)
+    return results
 
 
 def geocode_reverse(lat: float, lng: float) -> List[Dict]:
     """Reverse geocode a latitude and longitude pair using the API.
+
+    Results are cached using the Django cache framework keyed by the
+    ``lat`` and ``lng`` values.
 
     Parameters
     ----------
@@ -86,7 +100,14 @@ def geocode_reverse(lat: float, lng: float) -> List[Dict]:
         A list of simplified geocoding results.
     """
 
+    cache_key = f"geocode_reverse:{lat}:{lng}"
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return cached
+
     params = {"latlng": f"{lat},{lng}", "key": settings.GOOGLE_MAPS_API_KEY}
     response = requests.get(GEOCODE_ENDPOINT, params=params, timeout=10)
     data = response.json()
-    return _handle_response(data)
+    results = _handle_response(data)
+    cache.set(cache_key, results)
+    return results


### PR DESCRIPTION
## Summary
- cache forward and reverse geocoding responses

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689041b5989883318fdbf4b824e8b132