### PR TITLE
Add geocode API view and route

### DIFF
--- a/django_places_autocomplete/addresses/urls.py
+++ b/django_places_autocomplete/addresses/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
+
 from . import views
 
 urlpatterns = [
-    #path('admin/', admin.site.urls),
-    path('', views.address_form_view, name='address_form'),
-    path('list/', views.address_list_view, name='address_list'),
-    path('geocode/', views.geocode_view, name='geocode'),
+    path("", views.address_form_view, name="address_form"),
+    path("list/", views.address_list_view, name="address_list"),
+    # API endpoint for forward and reverse geocoding
+    path("geocode/", views.geocode_view, name="geocode"),
 ]


### PR DESCRIPTION
## Summary
- add API endpoint for forward and reverse geocoding
- expose geocode URL for addresses app

## Testing
- `pytest -q`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_689045d7fd0c8331b78a787f71710711