### PR TITLE
Add geocode fetch client

### DIFF
--- a/django_places_autocomplete/templates/addresses/address_form.html
+++ b/django_places_autocomplete/templates/addresses/address_form.html
@@ -85,7 +85,10 @@
       document.getElementById('display-country').textContent = c.country   || '';
       document.getElementById('display-postal').textContent  = c.postal_code || '';
 
-      geocodeAddress(place.formattedAddress);
+      const q = place.formattedAddress
+        ? {address: place.formattedAddress}
+        : {lat: place.location.lat, lng: place.location.lng};
+      geocodeAddress(q);
     }
 
     function set(id, v='') { const el=document.getElementById(id); if(el) el.value = v; }
@@ -97,10 +100,19 @@
       setTimeout(() => msgBox.classList.add('hidden'), 4000);
     }
 
-    async function geocodeAddress(query) {
-      if (!query) return;
+    async function geocodeAddress(opts) {
+      let url = '';
+      if (typeof opts === 'string' || (opts && opts.address)) {
+        const addr = typeof opts === 'string' ? opts : opts.address;
+        url = `/address/geocode/?address=${encodeURIComponent(addr)}`;
+      } else if (opts && opts.lat != null && opts.lng != null) {
+        url = `/address/geocode/?lat=${encodeURIComponent(opts.lat)}&lng=${encodeURIComponent(opts.lng)}`;
+      } else {
+        return;
+      }
+
       try {
-        const res = await fetch(`/address/geocode/?address=${encodeURIComponent(query)}`);
+        const res = await fetch(url);
         const data = await res.json();
         if (data.success && data.results.length) {
           const r = data.results[0];
@@ -109,7 +121,7 @@
           preview.classList.remove('hidden');
         } else {
           preview.classList.add('hidden');
-          show('No results found.', 'error');
+          show(data.error || 'No results found.', 'error');
         }
       } catch (err) {
         preview.classList.add('hidden');


### PR DESCRIPTION
## Summary
- call new geocode endpoint from address form
- handle forward/reverse geocoding responses

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689046cda9c083319d07d9d3e7ac30aa