### PR TITLE
Improve geocode fetch error handling

### DIFF
--- a/django_places_autocomplete/templates/addresses/address_form.html
+++ b/django_places_autocomplete/templates/addresses/address_form.html
@@ -113,6 +113,9 @@
 
       try {
         const res = await fetch(url);
+        if (!res.ok) {
+          throw new Error(`Request failed with status ${res.status}`);
+        }
         const data = await res.json();
         if (data.success && data.results.length) {
           const r = data.results[0];
@@ -125,7 +128,7 @@
         }
       } catch (err) {
         preview.classList.add('hidden');
-        show('Error fetching address data.', 'error');
+        show(err.message || 'Error fetching address data.', 'error');
       }
     }
 


### PR DESCRIPTION
## Summary
- Handle non-OK HTTP responses when requesting `/address/geocode` and surface error details to the user.

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689049321c84833183e03bf917e83f10