### PR TITLE
remove debug print and document tailwind build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Django Places Autocomplete
+
+Django demo project showcasing Google Maps Places Autocomplete and Geocoding API v4.
+
+## Tailwind CSS
+
+The project uses Tailwind CSS for styling. To generate the compiled stylesheet:
+
+```bash
+npm run build:css    # Build once
+npm run watch:css    # Rebuild on changes
+```
+
+The compiled file is written to `django_places_autocomplete/static/css/app.css` and is included in `base.html` via `{% static %}`.
+
+## Tests
+
+Run Django tests with:
+
+```bash
+python manage.py test
+```
+

--- a/django_places_autocomplete/myproject/settings.py
+++ b/django_places_autocomplete/myproject/settings.py
@@ -27,7 +27,6 @@ DEBUG       = env("DEBUG")
 SECRET_KEY  = env("SECRET_KEY")
 ALLOWED_HOSTS = ["localhost", "127.0.0.1"]
 
-print("GOOGLE_KEY:", env("GOOGLE_MAPS_API_KEY"))
 
 # ──────────────────────────────────────────────
 # Django basics


### PR DESCRIPTION
## Summary
- remove stray print statement that leaked `GOOGLE_MAPS_API_KEY` during startup
- document Tailwind CSS build and test commands in new README

## Testing
- `npm run build:css`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689035d424388331a6f4988cb3880334