### PR TITLE
Add browserslist update script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ npm run watch:css    # Rebuild on changes
 
 The compiled file is written to `django_places_autocomplete/static/css/app.css` and is included in `base.html` via `{% static %}`.
 
+If the build warns about outdated Browserslist data, update it:
+
+```bash
+npm run browserslist:update
+```
+
 ## Tests
 
 Run Django tests with:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build:css": "npx tailwindcss -c tailwind.config.js -i assets/css/input.css -o django_places_autocomplete/static/css/app.css --minify",
-    "watch:css": "npx tailwindcss -c tailwind.config.js -i assets/css/input.css -o django_places_autocomplete/static/css/app.css --watch"
+    "watch:css": "npx tailwindcss -c tailwind.config.js -i assets/css/input.css -o django_places_autocomplete/static/css/app.css --watch",
+    "browserslist:update": "npx update-browserslist-db@latest"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- add npm script for updating Browserslist data
- document how to update Browserslist data when build warns

## Testing
- `python manage.py test`
- `npm run browserslist:update`


------
https://chatgpt.com/codex/tasks/task_e_689052cc31fc8331ae0bf81572f5c028