### PR TITLE
Warn when Google Maps API key missing

### DIFF
--- a/django_places_autocomplete/myproject/settings.py
+++ b/django_places_autocomplete/myproject/settings.py
@@ -114,3 +114,8 @@ STATICFILES_STORAGE = (
 # API keys
 # ──────────────────────────────────────────────
 GOOGLE_MAPS_API_KEY = env("GOOGLE_MAPS_API_KEY")
+if not GOOGLE_MAPS_API_KEY:
+    import warnings
+    warnings.warn(
+        "GOOGLE_MAPS_API_KEY is not set; Google services will be unavailable."
+    )


### PR DESCRIPTION
## Summary
- warn during startup when GOOGLE_MAPS_API_KEY is unset

## Testing
- `python manage.py test`
- `python manage.py check`
- `python manage.py collectstatic --no-input`


------
https://chatgpt.com/codex/tasks/task_e_6890baf96c808331a1156b3880414dc9